### PR TITLE
Workarround to MS ReadDirectoryChanges bug

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1532,6 +1532,17 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_INTERNAL_CHECKDOCSTATUS:
 		{
+			// This is an workaround to deal with Microsoft issue in ReadDirectoryChanges notification
+			// If command prompt is used to write file continuously (e.g. ping -t 8.8.8.8 > ping.log)
+			// Then ReadDirectoryChanges does not detect the change.
+			// Fortunately, notification is sent if right click or double click happens on that file
+			// Let's leverage this as workaround to enhance npp file monitoring functionality.
+			// So calling "PathFileExists" is a workaround here.
+
+			Buffer* currBuf = getCurrentBuffer();
+			if (currBuf && currBuf->isMonitoringOn())
+				::PathFileExists(currBuf->getFullPathName());
+
 			const NppGUI & nppgui = pNppParam->getNppGUI();
 			if (nppgui._fileAutoDetection != cdDisabled)
 			{


### PR DESCRIPTION
This is an workaround to deal with Microsoft issue in ReadDirectoryChanges notification
If command prompt is used to write file continuously (e.g. ping -t 8.8.8.8 > ping.log)
Then ReadDirectoryChanges does not detect the change.
The workarround is about using Notepad++ notification while Notepad++ getting focus.

Close #5773